### PR TITLE
fix: 紧凑树布局在判断是否需要移动子节点时只判断了重叠情况,没有判断间距过大的情况

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ const NODE_SIZE = 16;
 const PEM = 5;
 const ctx = document.getElementById('id-of-canvas-element').getContext('2d');
 const rootNode = Hierarchy.compactBox(root, {
-  direction: 'H', // H / V / LR / RL / TB / BT
+  direction: 'H', // H / V / LR / RL / TB / BT,
+  forceCompact: true, // 开启强制紧凑，节点会以最小宽度和最小高度排列，不论节点在布局过程中是否重叠都会执行子树移动的行为
   getId(d) {
     return d.id;
   },

--- a/src/layout/non-layered-tidy.js
+++ b/src/layout/non-layered-tidy.js
@@ -93,6 +93,7 @@ function layer(node, isHorizontal, d = 0) {
 
 module.exports = (root, options = {}) => {
   const isHorizontal = options.isHorizontal;
+  const forceCompact = options.forceCompact;
   function firstWalk(t) {
     if (t.cs === 0) {
       setExtremes(t);
@@ -103,7 +104,7 @@ module.exports = (root, options = {}) => {
     for (let i = 1; i < t.cs; ++i) {
       firstWalk(t.c[i]);
       const min = bottom(t.c[i].er);
-      separate(t, i, ih);
+      separate(t, i, ih, forceCompact);
       ih = updateIYL(min, i, ih);
     }
     positionRoot(t);
@@ -123,7 +124,7 @@ module.exports = (root, options = {}) => {
     }
   }
 
-  function separate(t, i, ih) {
+  function separate(t, i, ih, forceCompact) {
     let sr = t.c[i - 1];
     let mssr = sr.mod;
     let cl = t.c[i];
@@ -131,7 +132,8 @@ module.exports = (root, options = {}) => {
     while (sr !== null && cl !== null) {
       if (bottom(sr) > ih.low) ih = ih.nxt;
       const dist = (mssr + sr.prelim + sr.w) - (mscl + cl.prelim);
-      if (dist > 0) {
+      // if forceCompact, the moveSubTree method is executed no matter what
+      if (forceCompact || dist > 0) {
         mscl += dist;
         moveSubtree(t, i, ih.index, dist);
       }


### PR DESCRIPTION
#16 紧凑树计算位置出错

新增 `forceCompact` 配置，开启后可以强制对子树位置进行计算以解决父节点被子节点撑开的问题