### PR TITLE
feat: support radial dendrogram

### DIFF
--- a/src/layout/do-layout.js
+++ b/src/layout/do-layout.js
@@ -69,7 +69,7 @@ module.exports = (root, options, layoutAlgrithm) => {
   }
 
   if (options.radial) {
-    const [rScale, radScale] = options.isHorizontal ? ["x", "y"] : ["y", "x"];
+    const [ rScale, radScale ] = options.isHorizontal ? [ "x", "y" ] : [ "y", "x" ];
 
     const min = { x: Infinity, y: Infinity };
     const max = { x: -Infinity, y: -Infinity };

--- a/src/layout/do-layout.js
+++ b/src/layout/do-layout.js
@@ -67,5 +67,36 @@ module.exports = (root, options, layoutAlgrithm) => {
   if (fixedRoot) {
     root.translate(-(root.x + root.width / 2 + root.hgap), -(root.y + root.height / 2 + root.vgap));
   }
+
+  if (options.radial) {
+    const [rScale, radScale] = options.isHorizontal ? ["x", "y"] : ["y", "x"];
+
+    const min = { x: Infinity, y: Infinity };
+    const max = { x: -Infinity, y: -Infinity };
+
+    let count = 0;
+    root.DFTraverse((node) => {
+      count++;
+      const { x, y } = node;
+      min.x = Math.min(min.x, x);
+      min.y = Math.min(min.y, y);
+      max.x = Math.max(max.x, x);
+      max.y = Math.max(max.y, y);
+    });
+
+    const radDiff = max[radScale] - min[radScale];
+    if (radDiff === 0) return root;
+
+    const avgRad = (Math.PI * 2) / count;
+    root.DFTraverse((node) => {
+      const rad =
+        ((node[radScale] - min[radScale]) / radDiff) * (Math.PI * 2 - avgRad) +
+        avgRad;
+      const r = node[rScale] - root[rScale];
+      node.x = Math.cos(rad) * r;
+      node.y = Math.sin(rad) * r;
+    });
+  }
+
   return root;
 };

--- a/src/layout/do-layout.js
+++ b/src/layout/do-layout.js
@@ -67,7 +67,6 @@ module.exports = (root, options, layoutAlgrithm) => {
     root.translate(-(root.x + root.width / 2 + root.hgap), -(root.y + root.height / 2 + root.vgap));
   }
 
- 
   reassignXYIfRadial(root, options);
 
   return root;
@@ -76,7 +75,7 @@ module.exports = (root, options, layoutAlgrithm) => {
 
 function reassignXYIfRadial(root, options) {
   if (options.radial) {
-    const [rScale, radScale] = options.isHorizontal ? ["x", "y"] : ["y", "x"];
+    const [ rScale, radScale ] = options.isHorizontal ? [ "x", "y" ] : [ "y", "x" ];
 
     const min = { x: Infinity, y: Infinity };
     const max = { x: -Infinity, y: -Infinity };

--- a/src/layout/do-layout.js
+++ b/src/layout/do-layout.js
@@ -1,4 +1,3 @@
-
 const separateTree = require('./separate-root');
 const VALID_DIRECTIONS = [
   'LR', // left to right
@@ -68,8 +67,16 @@ module.exports = (root, options, layoutAlgrithm) => {
     root.translate(-(root.x + root.width / 2 + root.hgap), -(root.y + root.height / 2 + root.vgap));
   }
 
+ 
+  reassignXYIfRadial(root, options);
+
+  return root;
+};
+
+
+function reassignXYIfRadial(root, options) {
   if (options.radial) {
-    const [ rScale, radScale ] = options.isHorizontal ? [ "x", "y" ] : [ "y", "x" ];
+    const [rScale, radScale] = options.isHorizontal ? ["x", "y"] : ["y", "x"];
 
     const min = { x: Infinity, y: Infinity };
     const max = { x: -Infinity, y: -Infinity };
@@ -85,7 +92,7 @@ module.exports = (root, options, layoutAlgrithm) => {
     });
 
     const radDiff = max[radScale] - min[radScale];
-    if (radDiff === 0) return root;
+    if (radDiff === 0) return;
 
     const avgRad = (Math.PI * 2) / count;
     root.DFTraverse((node) => {
@@ -97,6 +104,4 @@ module.exports = (root, options, layoutAlgrithm) => {
       node.y = Math.sin(rad) * r;
     });
   }
-
-  return root;
-};
+}


### PR DESCRIPTION
**Radial Dendrogram**

<img width="514" alt="Code 2024-08-26 20 01 10" src="https://github.com/user-attachments/assets/420eac8e-8d09-4fc9-91e9-517cec47c0c5">

**Tidy Radial Dendrogram (Compact Box)**

<img width="515" alt="Google Chrome 2024-08-26 20 00 48" src="https://github.com/user-attachments/assets/dbaa7728-ed85-4487-8242-60b4f46a9e82">
